### PR TITLE
feat: add documentation page with routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
 		"wrangler": "^4.50.0"
 	},
 	"dependencies": {
-		"@cloudflare/ai": "^1.2.2"
+		"@cloudflare/ai": "^1.2.2",
+		"lucide-react": "^0.546.0",
+		"react": "^18.3.1",
+		"react-dom": "^18.3.1",
+		"react-router-dom": "^7.9.6"
 	}
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,15 @@
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { Home } from './components/Home';
+import { Documentation } from './components/Documentation';
+
+export default function App() {
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/documentation" element={<Documentation />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}
+

--- a/src/components/Documentation.tsx
+++ b/src/components/Documentation.tsx
@@ -1,0 +1,107 @@
+export const Documentation = () => {
+  return (
+    <div className="min-h-screen bg-slate-50 bg-grid-slate-100">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+        <div className="mb-8">
+          <a href="/" className="text-blue-600 hover:text-blue-700 font-medium">
+            ← Back to Home
+          </a>
+        </div>
+
+        <h1 className="text-4xl font-extrabold text-slate-900 mb-6">
+          Documentation
+        </h1>
+        
+        <div className="prose prose-slate max-w-none">
+          <section className="bg-white rounded-2xl shadow-sm border border-slate-200 p-8 mb-8">
+            <h2 className="text-2xl font-bold text-slate-900 mb-4">Getting Started</h2>
+            <p className="text-slate-600 mb-4">
+              Welcome to the Lornuai Inc. Generative AI platform documentation. This platform is designed
+              to enhance engineering efficacy by automating critical workflows.
+            </p>
+            <p className="text-slate-600">
+              Our platform provides a measurable <strong>50-70% reduction</strong> in time and investment
+              for engineering tasks through specialized AI agents and workflow automation.
+            </p>
+          </section>
+
+          <section className="bg-white rounded-2xl shadow-sm border border-slate-200 p-8 mb-8">
+            <h2 className="text-2xl font-bold text-slate-900 mb-4">Platform Capabilities</h2>
+            
+            <div className="space-y-6">
+              <div>
+                <h3 className="text-xl font-semibold text-slate-900 mb-2">Generative Agents</h3>
+                <p className="text-slate-600">
+                  Deploy specialized AI agents that understand your specific codebase and architectural patterns.
+                  These agents can assist with code reviews, documentation generation, and architectural decisions.
+                </p>
+              </div>
+
+              <div>
+                <h3 className="text-xl font-semibold text-slate-900 mb-2">Workflow Automation</h3>
+                <p className="text-slate-600">
+                  Automate repetitive engineering tasks from PR reviews to documentation generation. Our platform
+                  integrates seamlessly with your existing development tools and processes.
+                </p>
+              </div>
+
+              <div>
+                <h3 className="text-xl font-semibold text-slate-900 mb-2">Efficacy Analytics</h3>
+                <p className="text-slate-600">
+                  Track the measurable impact of AI adoption on your team's velocity and code quality. Monitor
+                  time savings, automation rates, and ROI metrics in real-time.
+                </p>
+              </div>
+            </div>
+          </section>
+
+          <section className="bg-white rounded-2xl shadow-sm border border-slate-200 p-8 mb-8">
+            <h2 className="text-2xl font-bold text-slate-900 mb-4">API Reference</h2>
+            
+            <div className="space-y-4">
+              <div>
+                <h3 className="text-lg font-semibold text-slate-900 mb-2">
+                  <code className="bg-slate-100 px-2 py-1 rounded text-sm">GET /api/status</code>
+                </h3>
+                <p className="text-slate-600">
+                  Health check endpoint. Returns system status and available AI models.
+                </p>
+              </div>
+
+              <div>
+                <h3 className="text-lg font-semibold text-slate-900 mb-2">
+                  <code className="bg-slate-100 px-2 py-1 rounded text-sm">POST /api/query</code>
+                </h3>
+                <p className="text-slate-600 mb-2">
+                  Query AI models. Requires Cloudflare Access authentication.
+                </p>
+                <div className="bg-slate-50 p-4 rounded-lg">
+                  <p className="text-sm font-semibold text-slate-700 mb-2">Request Body:</p>
+                  <pre className="text-sm text-slate-600">
+{`{
+  "prompt": "Your query here",
+  "model": "llama-3.3-70b" // optional
+}`}
+                  </pre>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section className="bg-white rounded-2xl shadow-sm border border-slate-200 p-8">
+            <h2 className="text-2xl font-bold text-slate-900 mb-4">Authentication</h2>
+            <p className="text-slate-600 mb-4">
+              This platform is protected by Cloudflare Access and requires Google Workspace authentication
+              with an <strong>@lornu.ai</strong> email address.
+            </p>
+            <p className="text-slate-600">
+              All API requests are automatically authenticated through Cloudflare Access JWT tokens.
+              No additional API keys are required for internal employees.
+            </p>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+};
+

--- a/src/components/FeatureCard.tsx
+++ b/src/components/FeatureCard.tsx
@@ -1,0 +1,16 @@
+interface FeatureCardProps {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+}
+
+export const FeatureCard = ({ icon, title, description }: FeatureCardProps) => {
+  return (
+    <div className="bg-white rounded-lg shadow-sm border border-slate-200 p-6">
+      <div className="text-blue-600 mb-4">{icon}</div>
+      <h3 className="text-xl font-semibold text-slate-900 mb-2">{title}</h3>
+      <p className="text-slate-600">{description}</p>
+    </div>
+  );
+};
+

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,12 @@
+export const Footer = () => {
+  return (
+    <footer className="bg-slate-900 text-white py-12">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="text-center">
+          <p className="text-slate-400">© 2025 Lornu AI. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  );
+};
+

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,16 @@
+export const Header = () => {
+  return (
+    <header className="bg-white shadow-sm">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+        <div className="flex items-center justify-between">
+          <div className="text-xl font-bold text-slate-900">Lornu AI</div>
+          <nav className="space-x-4">
+            <a href="/" className="text-slate-600 hover:text-slate-900">Home</a>
+            <a href="/documentation" className="text-slate-600 hover:text-slate-900">Documentation</a>
+          </nav>
+        </div>
+      </div>
+    </header>
+  );
+};
+

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,0 +1,23 @@
+import { Link } from 'react-router-dom';
+
+export const Hero = () => {
+  return (
+    <section className="bg-gradient-to-r from-blue-600 to-indigo-600 text-white py-24">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+        <h1 className="text-5xl font-extrabold mb-6">
+          Generative AI Platform
+        </h1>
+        <p className="text-xl mb-8 max-w-2xl mx-auto">
+          Enhance engineering efficacy with specialized AI agents and workflow automation.
+        </p>
+        <Link
+          to="/documentation"
+          className="inline-block bg-white text-blue-600 px-6 py-3 rounded-lg font-semibold hover:bg-blue-50 transition"
+        >
+          View Documentation
+        </Link>
+      </div>
+    </section>
+  );
+};
+

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -1,0 +1,64 @@
+import { Bot, Workflow, BarChart3 } from 'lucide-react';
+import { Header } from './Header';
+import { Hero } from './Hero';
+import { FeatureCard } from './FeatureCard';
+import { StatsSection } from './StatsSection';
+import { Footer } from './Footer';
+
+const features = [
+  {
+    icon: <Bot className="h-6 w-6" />,
+    title: "Generative Agents",
+    description: "Deploy specialized AI agents that understand your specific codebase and architectural patterns."
+  },
+  {
+    icon: <Workflow className="h-6 w-6" />,
+    title: "Workflow Automation",
+    description: "Automate repetitive engineering tasks from PR reviews to documentation generation."
+  },
+  {
+    icon: <BarChart3 className="h-6 w-6" />,
+    title: "Efficacy Analytics",
+    description: "Track the measurable impact of AI adoption on your team's velocity and code quality."
+  }
+];
+
+export const Home = () => {
+  return (
+    <div className="min-h-screen bg-slate-50 bg-grid-slate-100">
+      <Header />
+
+      <main>
+        <Hero />
+
+        <StatsSection />
+
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24">
+          <div className="text-center mb-16">
+            <h2 className="text-3xl font-bold text-slate-900 mb-4">
+              Platform Capabilities
+            </h2>
+            <p className="text-lg text-slate-600 max-w-2xl mx-auto">
+              Built for scaling teams, our platform integrates seamlessly into your existing stack
+              to supercharge development.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+            {features.map((feature) => (
+              <FeatureCard
+                key={feature.title}
+                icon={feature.icon}
+                title={feature.title}
+                description={feature.description}
+              />
+            ))}
+          </div>
+        </div>
+      </main>
+
+      <Footer />
+    </div>
+  );
+};
+

--- a/src/components/StatsSection.tsx
+++ b/src/components/StatsSection.tsx
@@ -1,0 +1,23 @@
+export const StatsSection = () => {
+  return (
+    <section className="bg-slate-100 py-16">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-8 text-center">
+          <div>
+            <div className="text-4xl font-bold text-blue-600 mb-2">50-70%</div>
+            <div className="text-slate-600">Time Reduction</div>
+          </div>
+          <div>
+            <div className="text-4xl font-bold text-blue-600 mb-2">24/7</div>
+            <div className="text-slate-600">AI Availability</div>
+          </div>
+          <div>
+            <div className="text-4xl font-bold text-blue-600 mb-2">100%</div>
+            <div className="text-slate-600">Automation Ready</div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+


### PR DESCRIPTION
Adds a comprehensive documentation page accessible at `/documentation` route.

## Changes
- ✅ Install react-router-dom for client-side routing
- ✅ Create Documentation component with platform overview
- ✅ Extract Home component from App.tsx
- ✅ Add routing for `/` and `/documentation` paths
- ✅ Document API endpoints (`/api/status`, `/api/query`)
- ✅ Document authentication flow with Cloudflare Access
- ✅ Include platform capabilities and getting started guide

## Features
The documentation page includes:
- Getting started guide
- Platform capabilities (Generative Agents, Workflow Automation, Analytics)
- API reference with examples
- Authentication requirements

Fixes the broken `/documentation` link in the Hero component's "View Documentation" button.