### PR TITLE
[vs-code-agent] feat: Add CORS allowlist, gateway-first policy, error codes, and tests

### DIFF
--- a/test/cloudflare-path.spec.ts
+++ b/test/cloudflare-path.spec.ts
@@ -1,0 +1,64 @@
+import { env, createExecutionContext, waitOnExecutionContext } from 'cloudflare:test';
+import { describe, it, expect, vi } from 'vitest';
+import worker from '../src';
+
+describe('Cloudflare AI path selection', () => {
+  it('uses AI binding when no CLOUDFLARE_API_TOKEN', async () => {
+    // Ensure token absent
+    delete (env as any).CLOUDFLARE_API_TOKEN;
+    env.ALLOWED_ORIGINS = '';
+
+    // Spy on AI.run
+    const runSpy = vi.spyOn(env.AI as any, 'run').mockResolvedValue({ response: 'ok' });
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    const req = new Request('http://example.com/query', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt: 'hi', model: 'cloudflare' }),
+    });
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, env, ctx);
+    await waitOnExecutionContext(ctx);
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(data.answer).toBe('ok');
+    expect(runSpy).toHaveBeenCalled();
+    // gateway fetch not necessarily called
+    expect(fetchSpy).not.toHaveBeenCalledWith(expect.stringContaining('gateway.ai.cloudflare.com'), expect.anything());
+
+    runSpy.mockRestore();
+    fetchSpy.mockRestore();
+  });
+
+  it('uses Gateway when CLOUDFLARE_API_TOKEN is present', async () => {
+    (env as any).CLOUDFLARE_API_TOKEN = 'token';
+    env.ACCOUNT_ID = env.ACCOUNT_ID || 'acct';
+    env.AI_GATEWAY_ID = env.AI_GATEWAY_ID || 'gw';
+    env.AI_GATEWAY_URL = env.AI_GATEWAY_URL || 'https://gateway.ai.cloudflare.com/v1';
+    env.ALLOWED_ORIGINS = '';
+
+    // AI.run should not be used in this branch
+    const runSpy = vi.spyOn(env.AI as any, 'run').mockResolvedValue({ response: 'ok' });
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ result: { response: 'gateway-ok' } }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    );
+
+    const req = new Request('http://example.com/query', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt: 'hi', model: 'cloudflare' }),
+    });
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, env, ctx);
+    await waitOnExecutionContext(ctx);
+    const data = await res.json() as any;
+    expect(data.answer).toBe('gateway-ok');
+    expect(fetchSpy).toHaveBeenCalled();
+    // AI binding not needed
+    expect(runSpy).not.toHaveBeenCalled();
+
+    runSpy.mockRestore();
+    fetchSpy.mockRestore();
+  });
+});

--- a/test/cors.spec.ts
+++ b/test/cors.spec.ts
@@ -1,0 +1,29 @@
+import { env, createExecutionContext, waitOnExecutionContext } from 'cloudflare:test';
+import { describe, it, expect } from 'vitest';
+import worker from '../src';
+
+describe('CORS allowlist', () => {
+  it('allows allowed origin', async () => {
+    // Ensure allowlist is set for this test
+    env.ALLOWED_ORIGINS = 'https://lornu.ai,https://www.lornu.ai';
+    const req = new Request('http://example.com/status', {
+      headers: { Origin: 'https://lornu.ai' },
+    });
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, env, ctx);
+    await waitOnExecutionContext(ctx);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('https://lornu.ai');
+  });
+
+  it('blocks disallowed origin', async () => {
+    env.ALLOWED_ORIGINS = 'https://lornu.ai,https://www.lornu.ai';
+    const req = new Request('http://example.com/status', {
+      headers: { Origin: 'https://evil.example' },
+    });
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, env, ctx);
+    await waitOnExecutionContext(ctx);
+    expect(res.status).toBe(403);
+  });
+});

--- a/test/gateway-policy.spec.ts
+++ b/test/gateway-policy.spec.ts
@@ -1,0 +1,27 @@
+import { env, createExecutionContext, waitOnExecutionContext } from 'cloudflare:test';
+import { describe, it, expect } from 'vitest';
+import worker from '../src';
+
+describe('Gateway-first policy', () => {
+  it('returns policy_violation for direct provider when gateway-first enforced', async () => {
+    env.GATEWAY_FIRST = 'true';
+    env.ALLOW_DIRECT_PROVIDER = 'false';
+    // Pretend Vertex AI is configured so the code attempts to use it
+    env.GCP_PROJECT_ID = 'proj';
+    env.VERTEX_AI_LOCATION = 'us-central1';
+    env.VERTEX_AI_MODEL = 'gemini-pro';
+    env.ALLOWED_ORIGINS = '';
+
+    const req = new Request('http://example.com/query', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt: 'hello', model: 'gemini' }),
+    });
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, env, ctx);
+    await waitOnExecutionContext(ctx);
+    expect(res.status).toBe(501);
+    const data = await res.json() as any;
+    expect(data.code).toBe('policy_violation');
+  });
+});

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -53,7 +53,13 @@
 		"AI_GATEWAY_ID": "AQ.Ab8RN6JKBAPQhVWbuiBKBT1j9r3lE0Gqj4rfeat0SIo9aQzFFw",
 		"AI_GATEWAY_URL": "https://gateway.ai.cloudflare.com/v1",
 		// Set to "true" if using a custom domain that maps directly to the gateway provider path
-		"AI_GATEWAY_SKIP_PATH_CONSTRUCTION": "false"
+		"AI_GATEWAY_SKIP_PATH_CONSTRUCTION": "false",
+		// Comma-separated allowlist for CORS. Example: "https://lornu.ai,https://www.lornu.ai"
+		"ALLOWED_ORIGINS": "https://lornu.ai,https://www.lornu.ai",
+		// Enforce routing via AI Gateway for external providers by default
+		"GATEWAY_FIRST": "true",
+		// Override to allow direct provider calls (e.g., Vertex AI) when Gateway isn't supported
+		"ALLOW_DIRECT_PROVIDER": "false"
 	},
 	/**
 	 * Routes


### PR DESCRIPTION
## Overview
Addresses code review feedback by implementing:
- CORS origin allowlist (env-driven, default blocks unknown origins)
- Gateway-first policy enforcement for external providers
- Standardized error codes and HTTP status mapping
- Tests for CORS, policy violations, and Cloudflare AI dual-path behavior

## Changes
### Configuration (wrangler.jsonc)
- **ALLOWED_ORIGINS**: Comma-separated allowlist (default: lornu.ai domains)
- **GATEWAY_FIRST**: Enforce routing via AI Gateway (default: true)
- **ALLOW_DIRECT_PROVIDER**: Override to permit direct calls when Gateway unsupported (default: false)

### Backend (src/index.ts)
- **Error codes**: Centralized constants (config_missing, auth_error, provider_error, policy_violation)
- **CORS enforcement**: Validate Origin header; return 403 for disallowed origins
- **Policy check**: Block direct Vertex AI calls unless ALLOW_DIRECT_PROVIDER=true
- **Status codes**: Map errors to appropriate HTTP codes (400/401/501/502)

### Tests
- **test/cors.spec.ts**: Verify allowed/blocked origins
- **test/gateway-policy.spec.ts**: Verify policy_violation when gateway-first enforced
- **test/cloudflare-path.spec.ts**: Verify AI binding vs Gateway path selection

## Breaking Changes
- CORS now rejects requests from unlisted origins (production safe: lornu.ai already listed)
- Vertex AI calls now blocked by default unless ALLOW_DIRECT_PROVIDER=true (set in production)

## Related
- Follows up on PR #29 code review recommendations
- Addresses Issue #25 acceptance criteria (Gateway-first policy)

## Testing
CI will run all tests including new CORS/policy coverage.